### PR TITLE
HOTT-1938: Configure signonotron2 for trade-tariff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,335 @@
+version: 2.1
+
+orbs:
+  aws-cli: circleci/aws-cli@2.0.3
+  ruby: circleci/ruby@1
+  cloudfoundry: circleci/cloudfoundry@1.0
+  slack: circleci/slack@4.3.0
+  queue: eddiewebb/queue@1.6.4
+  tariff: trade-tariff/trade-tariff-ci-orb@0 # can also change to @dev:<gitsha> for specific version or @dev:alpha to test dev branches
+
+commands:
+  cf_deploy_docker:
+    parameters:
+      docker_image_tag:
+        type: string
+      space:
+        type: string
+      environment_key:
+        type: string
+    steps:
+      - checkout
+      - tariff/cf-install:
+          space: << parameters.space >>
+      - run:
+          name: "Fetch existing manifest"
+          command: |
+            cf create-app-manifest "signon-<< parameters.environment_key >>" -p deploy_manifest.yml
+      - run:
+          name: "Push new app in dark mode"
+          command: |
+            export DOCKER_IMAGE=signon
+            export DOCKER_TAG="<< parameters.docker_image_tag >>"
+
+            # Push as "dark" instance
+            CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push "signon-<< parameters.environment_key >>-dark" -f deploy_manifest.yml --no-route  --docker-image "$ECR_REPO/$DOCKER_IMAGE:$DOCKER_TAG" --docker-username "$AWS_ACCESS_KEY_ID"
+
+            # Map dark route
+            cf map-route  "signon-<< parameters.environment_key >>-dark" apps.internal -n "signon-<< parameters.environment_key >>-dark"
+
+            # Attach precreated autoscaling policy
+            cf attach-autoscaling-policy "signon-<< parameters.environment_key >>-dark" config/autoscaling/<< parameters.space >>-policy.json
+
+            # Enable routing from this frontend to backend applications which are private
+            cf add-network-policy "$CF_FRONTEND_APP-<< parameters.environment_key >>" "signon-<< parameters.environment_key >>-dark" --protocol tcp --port 8080
+            cf add-network-policy "$CF_ADMIN_APP-<< parameters.environment_key >>" "signon-<< parameters.environment_key >>-dark" --protocol tcp --port 8080
+            cf add-network-policy "$CF_DUTYCALCULATOR_APP-<< parameters.environment_key >>" "signon-<< parameters.environment_key >>-dark" --protocol tcp --port 8080
+            cf add-network-policy "signon-<< parameters.environment_key >>-dark" "tariff-search-query-parser-<< parameters.environment_key >>" --protocol tcp --port 8080
+
+      - run:
+          name: "Verify new version is working on dark URL."
+          command: |
+            sleep 15
+            # Verify new version is working on dark URL.
+            APP_NAME="signon-<< parameters.environment_key >>-dark"
+
+            HTTPCODE=`cf ssh $APP_NAME -c 'curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/healthcheck/ready'`
+
+            if [ "$HTTPCODE" -ne 200 ];then
+              echo "dark route not available, failing deploy ($HTTPCODE)"
+              cf logs "signon-<< parameters.environment_key >>-dark" --recent
+              cf delete -f "signon-<< parameters.environment_key >>-dark"
+              exit 1
+            fi
+      - run:
+          name: "Switch dark app to live"
+          command: |
+            # Send "real" url to new version
+            cf unmap-route  "signon-<< parameters.environment_key >>-dark" apps.internal -n "signon-<< parameters.environment_key >>-dark"
+
+            # Start sending traffic to new version
+            cf map-route "signon-<< parameters.environment_key >>-dark" apps.internal -n "signon-<< parameters.environment_key >>"
+            cf map-route "signon-<< parameters.environment_key >>-dark" "<< parameters.domain_prefix >>.trade-tariff.service.gov.uk" --path "/<< parameters.service >>/api/beta/"
+
+            # Stop sending traffic to previous version
+            cf unmap-route "signon-<< parameters.environment_key >>" apps.internal -n "signon-<< parameters.environment_key >>"
+            cf unmap-route "signon-<< parameters.environment_key >>" "<< parameters.domain_prefix >>.trade-tariff.service.gov.uk" --path "/<< parameters.service >>/api/beta/"
+
+            # stop previous version
+            cf stop "signon-<< parameters.environment_key >>"
+
+            # delete previous version
+            cf delete "signon-<< parameters.environment_key >>" -f
+
+            # Switch name of "dark" version to claim correct name
+            cf rename "signon-<< parameters.environment_key >>-dark" "signon-<< parameters.environment_key >>"
+
+      - slack/notify:
+          channel: deployments
+          event: fail
+          template: basic_fail_1
+      - slack/notify:
+          channel: deployments
+          event: pass
+          template: basic_success_1
+  cf_deploy_docker_worker:
+    parameters:
+      docker_image_tag:
+        type: string
+      space:
+        type: string
+      service:
+        type: string
+      environment_key:
+        type: string
+    steps:
+      - checkout
+      - tariff/cf-install:
+          space: << parameters.space >>
+      - run:
+          name: "Fetch existing manifest"
+          command: |
+            cf create-app-manifest "signon-worker-<< parameters.environment_key >>" -p deploy_manifest.yml
+      - run:
+          name: "Push Worker"
+          command: |
+            export DOCKER_IMAGE=tariff-backend
+            export DOCKER_TAG="<< parameters.docker_image_tag >>"
+            CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push "signon-worker-<< parameters.environment_key >>" -f deploy_manifest.yml --no-route --docker-image "$ECR_REPO/$DOCKER_IMAGE:$DOCKER_TAG" --docker-username "$AWS_ACCESS_KEY_ID"
+
+  cf_deploy_docker_tasks:
+    parameters:
+      docker_image_tag:
+        type: string
+      space:
+        type: string
+      service:
+        type: string
+      environment_key:
+        type: string
+    steps:
+      - checkout
+      - tariff/cf-install:
+          space: << parameters.space >>
+      - run:
+          name: "Create tasks app manifest"
+          command: |
+            cf create-app-manifest "signon-worker-<< parameters.environment_key >>" -p tasks_deploy_manifest.yml
+      - run:
+          name: "Push Tasks app"
+          command: |
+            export DOCKER_IMAGE=tariff-backend
+            export DOCKER_TAG="<< parameters.docker_image_tag >>"
+            CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push "signon-tasks-<< parameters.environment_key >>" \
+                                                               -f tasks_deploy_manifest.yml \
+                                                               --no-route \
+                                                               --task \
+                                                               --docker-image "$ECR_REPO/$DOCKER_IMAGE:$DOCKER_TAG" \
+                                                               --docker-username "$AWS_ACCESS_KEY_ID"
+      - run_migrations:
+          environment_key: << parameters.environment_key >>
+
+  sentry-release:
+    steps:
+      - checkout
+      - run:
+          name: Create release and notify Sentry of deploy
+          command: |
+            sudo curl -sL \
+                      -o /usr/local/bin/sentry-cli \
+                      https://github.com/getsentry/sentry-cli/releases/download/1.74.3/sentry-cli-Linux-x86_64
+            sudo chmod 0755 /usr/local/bin/sentry-cli
+            export SENTRY_RELEASE=$(sentry-cli releases propose-version)
+            sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE &&
+              sentry-cli releases set-commits $SENTRY_RELEASE --auto &&
+              sentry-cli releases finalize $SENTRY_RELEASE &&
+              sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT ||
+              /usr/bin/true # prevent sentry outage from blocking deploys - see HOTT-1570
+
+  run_migrations:
+    parameters:
+      service:
+        type: string
+      environment_key:
+        type: string
+    steps:
+      - run:
+          name: "Run Migrations"
+          command: |
+            cf run-task "signon-tasks-<< parameters.environment_key >>" --command "cd app && bundle exec rails db:migrate" --name "db-migrate" --wait
+
+jobs:
+  linters:
+    docker:
+      - image: cimg/ruby:2.7.6
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Install C lib dependencies
+          command: |
+            sudo apt update
+            sudo apt-get install -y --no-install-suggests --no-install-recommends nodejs libmariadb-dev-compat
+      - ruby/install-deps
+      - run:
+          name: Rubocop changed files
+          when: always
+          command: bundle exec rubocop $(git diff --name-only --diff-filter=ACM $(git merge-base main HEAD)..HEAD | egrep '\.rb|\.rake') Gemfile
+      - run:
+          name: Inspecting with Brakeman
+          when: always
+          command: "bundle exec brakeman -o test-results/brakeman/brakeman.junit -o brakeman.html --no-progress --separate-models"
+      - store_test_results:
+          path: test-results/brakeman/
+      - store_artifacts:
+          path: brakeman.html
+
+  build:
+    environment:
+      IMAGE_NAME: signon
+    parameters:
+      dev-build:
+        default: false
+        type: boolean
+    docker:
+      - image: cimg/ruby:2.7.6
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.11
+          docker_layer_caching: false
+      - aws-cli/install
+      - run:
+          name: "Set docker tag"
+          command: |
+            echo "export DOCKER_TAG=<<# parameters.dev-build >>dev-<</ parameters.dev-build >>${CIRCLE_SHA1}" >> $BASH_ENV
+      - run:
+          name: "Build Docker image"
+          command: |
+            export GIT_NEW_REVISION=$(git rev-parse --short HEAD)
+            echo $GIT_NEW_REVISION >REVISION
+            docker build -t $IMAGE_NAME:$DOCKER_TAG .
+      - run:
+          name: "Push image"
+          command: |
+            aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin $ECR_REPO
+            docker tag $IMAGE_NAME:$DOCKER_TAG $ECR_REPO/$IMAGE_NAME:$DOCKER_TAG
+            docker push $ECR_REPO/$IMAGE_NAME:$DOCKER_TAG
+
+  test:
+    docker:
+      - image: cimg/ruby:2.7.6
+        environment:
+          BUNDLE_JOBS: "3"
+          BUNDLE_RETRY: "3"
+          RAILS_ENV: "test"
+          DATABASE_URL: "mysql://signonotron2:signonotron2@localhost:3306/signonotron2_test"
+          REDIS_URL: "redis://localhost:6379"
+      - image: cimg/mysql:8.0
+        environment:
+          MYSQL_DATABASE: signonotron2_test
+          MYSQL_USER: signonotron2
+          MYSQL_PASSWORD: signonotron2
+      - image: cimg/redis:6.2.6
+    resource_class: medium
+    steps:
+      - checkout
+      - run:
+          name: "Install OS packages"
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y --no-install-suggests --no-install-recommends nodejs libmariadb-dev-compat
+      - ruby/install-deps
+      - run:
+          name: "Setup DB"
+          command: |
+            RAILS_ENV=test bundle exec rails db:schema:load
+      - run:
+          name: "Run tests"
+          command: |
+            RAILS_ENV=test bundle exec rake test
+      - slack/notify: # TODO: Remove once proven
+          channel: deployments
+          event: pass
+          template: basic_success_1
+      - slack/notify:
+          channel: deployments
+          event: fail
+          template: basic_fail_1
+
+  # deploy_dev:
+  #   docker:
+  #     - image: cimg/ruby:2.7.6
+  #   environment:
+  #     SENTRY_ENVIRONMENT: "development"
+  #   steps:
+  #     - queue/until_front_of_line:
+  #         time: "10"
+  #         consider-branch: false
+  #         dont-quit: true
+  #     - cf_deploy_docker_tasks:
+  #         docker_image_tag: dev-$CIRCLE_SHA1
+  #         space: "development"
+  #         environment_key: "dev"
+  #     - cf_deploy_docker_worker:
+  #         docker_image_tag: dev-$CIRCLE_SHA1
+  #         space: "development"
+  #         environment_key: "dev"
+  #     - cf_deploy_docker:
+  #         docker_image_tag: dev-$CIRCLE_SHA1
+  #         space: "development"
+  #         environment_key: "dev"
+  #         domain_prefix: "dev"
+  #     - sentry-release
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - linters:
+          context: trade-tariff
+      - test:
+          context: trade-tariff
+          filters:
+            branches:
+              ignore:
+                - main
+      - build:
+          name: build_dev
+          context: trade-tariff
+          dev-build: true
+          filters:
+            branches:
+              ignore:
+                - main
+                - /^dependabot\/.*/
+      # - deploy_dev:
+      #     context: trade-tariff
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - main
+      #           - /^dependabot\/.*/
+      #     requires:
+      #       - test
+      #       - build_dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,13 +45,13 @@ commands:
             # Verify new version is working on dark URL.
             APP_NAME="signon-<< parameters.environment_key >>-dark"
 
-            HTTPCODE=`cf ssh $APP_NAME -c 'curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/healthcheck/api-tokens'`
+            HTTPCODE=`cf ssh $APP_NAME -c 'curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/healthcheck/api-tokens'`
 
             if [ "$HTTPCODE" -ne 200 ]
             then
               echo "dark route not available, failing deploy ($HTTPCODE)"
               cf logs "signon-<< parameters.environment_key >>-dark" --recent
-              cf delete -f "signon-<< parameters.environment_key >>-dark"
+              # cf delete -f "signon-<< parameters.environment_key >>-dark"
               exit 1
             fi
       - run:
@@ -292,14 +292,14 @@ workflows:
   version: 2
   ci:
     jobs:
-      - linters:
-          context: trade-tariff
-      - test:
-          context: trade-tariff
-          filters:
-            branches:
-              ignore:
-                - main
+      # - linters:
+      #     context: trade-tariff
+      # - test:
+      #     context: trade-tariff
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - main
       - build:
           name: build_dev
           context: trade-tariff
@@ -317,5 +317,5 @@ workflows:
                 - main
                 - /^dependabot\/.*/
           requires:
-            - test
+            # - test
             - build_dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,16 +36,7 @@ commands:
             CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push "signon-<< parameters.environment_key >>-dark" -f deploy_manifest.yml --no-route  --docker-image "$ECR_REPO/$DOCKER_IMAGE:$DOCKER_TAG" --docker-username "$AWS_ACCESS_KEY_ID"
 
             # Map dark route
-            cf map-route  "signon-<< parameters.environment_key >>-dark" apps.internal -n "signon-<< parameters.environment_key >>-dark"
-
-            # Attach precreated autoscaling policy
-            cf attach-autoscaling-policy "signon-<< parameters.environment_key >>-dark" config/autoscaling/<< parameters.space >>-policy.json
-
-            # Enable routing from this frontend to backend applications which are private
-            cf add-network-policy "$CF_FRONTEND_APP-<< parameters.environment_key >>" "signon-<< parameters.environment_key >>-dark" --protocol tcp --port 8080
-            cf add-network-policy "$CF_ADMIN_APP-<< parameters.environment_key >>" "signon-<< parameters.environment_key >>-dark" --protocol tcp --port 8080
-            cf add-network-policy "$CF_DUTYCALCULATOR_APP-<< parameters.environment_key >>" "signon-<< parameters.environment_key >>-dark" --protocol tcp --port 8080
-            cf add-network-policy "signon-<< parameters.environment_key >>-dark" "tariff-search-query-parser-<< parameters.environment_key >>" --protocol tcp --port 8080
+            cf map-route  "signon-<< parameters.environment_key >>-dark" london.cloudapps.digital --hostname "signon-<< parameters.environment_key >>-dark"
 
       - run:
           name: "Verify new version is working on dark URL."
@@ -54,9 +45,10 @@ commands:
             # Verify new version is working on dark URL.
             APP_NAME="signon-<< parameters.environment_key >>-dark"
 
-            HTTPCODE=`cf ssh $APP_NAME -c 'curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/healthcheck/ready'`
+            HTTPCODE=`cf ssh $APP_NAME -c 'curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/healthcheck/api-tokens'`
 
-            if [ "$HTTPCODE" -ne 200 ];then
+            if [ "$HTTPCODE" -ne 200 ]
+            then
               echo "dark route not available, failing deploy ($HTTPCODE)"
               cf logs "signon-<< parameters.environment_key >>-dark" --recent
               cf delete -f "signon-<< parameters.environment_key >>-dark"
@@ -66,20 +58,17 @@ commands:
           name: "Switch dark app to live"
           command: |
             # Send "real" url to new version
-            cf unmap-route  "signon-<< parameters.environment_key >>-dark" apps.internal -n "signon-<< parameters.environment_key >>-dark"
+            cf unmap-route "signon-<< parameters.environment_key >>-dark" london.cloudapps.digital --hostname "signon-<< parameters.environment_key >>-dark"
 
             # Start sending traffic to new version
-            cf map-route "signon-<< parameters.environment_key >>-dark" apps.internal -n "signon-<< parameters.environment_key >>"
-            cf map-route "signon-<< parameters.environment_key >>-dark" "<< parameters.domain_prefix >>.trade-tariff.service.gov.uk" --path "/<< parameters.service >>/api/beta/"
+            cf map-route "signon-<< parameters.environment_key >>-dark" london.cloudapps.digital --hostname "signon-<< parameters.environment_key >>"
 
             # Stop sending traffic to previous version
-            cf unmap-route "signon-<< parameters.environment_key >>" apps.internal -n "signon-<< parameters.environment_key >>"
-            cf unmap-route "signon-<< parameters.environment_key >>" "<< parameters.domain_prefix >>.trade-tariff.service.gov.uk" --path "/<< parameters.service >>/api/beta/"
-
-            # stop previous version
+            cf unmap-route "signon-<< parameters.environment_key >>" london.cloudapps.digital --hostname "signon-<< parameters.environment_key >>"
+            # Stop previous version
             cf stop "signon-<< parameters.environment_key >>"
 
-            # delete previous version
+            # Delete previous version
             cf delete "signon-<< parameters.environment_key >>" -f
 
             # Switch name of "dark" version to claim correct name
@@ -93,91 +82,91 @@ commands:
           channel: deployments
           event: pass
           template: basic_success_1
-  cf_deploy_docker_worker:
-    parameters:
-      docker_image_tag:
-        type: string
-      space:
-        type: string
-      service:
-        type: string
-      environment_key:
-        type: string
-    steps:
-      - checkout
-      - tariff/cf-install:
-          space: << parameters.space >>
-      - run:
-          name: "Fetch existing manifest"
-          command: |
-            cf create-app-manifest "signon-worker-<< parameters.environment_key >>" -p deploy_manifest.yml
-      - run:
-          name: "Push Worker"
-          command: |
-            export DOCKER_IMAGE=tariff-backend
-            export DOCKER_TAG="<< parameters.docker_image_tag >>"
-            CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push "signon-worker-<< parameters.environment_key >>" -f deploy_manifest.yml --no-route --docker-image "$ECR_REPO/$DOCKER_IMAGE:$DOCKER_TAG" --docker-username "$AWS_ACCESS_KEY_ID"
+  # cf_deploy_docker_worker:
+  #   parameters:
+  #     docker_image_tag:
+  #       type: string
+  #     space:
+  #       type: string
+  #     service:
+  #       type: string
+  #     environment_key:
+  #       type: string
+  #   steps:
+  #     - checkout
+  #     - tariff/cf-install:
+  #         space: << parameters.space >>
+  #     - run:
+  #         name: "Fetch existing manifest"
+  #         command: |
+  #           cf create-app-manifest "signon-worker-<< parameters.environment_key >>" -p deploy_manifest.yml
+  #     - run:
+  #         name: "Push Worker"
+  #         command: |
+  #           export DOCKER_IMAGE=tariff-backend
+  #           export DOCKER_TAG="<< parameters.docker_image_tag >>"
+  #           CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push "signon-worker-<< parameters.environment_key >>" -f deploy_manifest.yml --no-route --docker-image "$ECR_REPO/$DOCKER_IMAGE:$DOCKER_TAG" --docker-username "$AWS_ACCESS_KEY_ID"
 
-  cf_deploy_docker_tasks:
-    parameters:
-      docker_image_tag:
-        type: string
-      space:
-        type: string
-      service:
-        type: string
-      environment_key:
-        type: string
-    steps:
-      - checkout
-      - tariff/cf-install:
-          space: << parameters.space >>
-      - run:
-          name: "Create tasks app manifest"
-          command: |
-            cf create-app-manifest "signon-worker-<< parameters.environment_key >>" -p tasks_deploy_manifest.yml
-      - run:
-          name: "Push Tasks app"
-          command: |
-            export DOCKER_IMAGE=tariff-backend
-            export DOCKER_TAG="<< parameters.docker_image_tag >>"
-            CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push "signon-tasks-<< parameters.environment_key >>" \
-                                                               -f tasks_deploy_manifest.yml \
-                                                               --no-route \
-                                                               --task \
-                                                               --docker-image "$ECR_REPO/$DOCKER_IMAGE:$DOCKER_TAG" \
-                                                               --docker-username "$AWS_ACCESS_KEY_ID"
-      - run_migrations:
-          environment_key: << parameters.environment_key >>
+  # cf_deploy_docker_tasks:
+  #   parameters:
+  #     docker_image_tag:
+  #       type: string
+  #     space:
+  #       type: string
+  #     service:
+  #       type: string
+  #     environment_key:
+  #       type: string
+  #   steps:
+  #     - checkout
+  #     - tariff/cf-install:
+  #         space: << parameters.space >>
+  #     - run:
+  #         name: "Create tasks app manifest"
+  #         command: |
+  #           cf create-app-manifest "signon-worker-<< parameters.environment_key >>" -p tasks_deploy_manifest.yml
+  #     - run:
+  #         name: "Push Tasks app"
+  #         command: |
+  #           export DOCKER_IMAGE=tariff-backend
+  #           export DOCKER_TAG="<< parameters.docker_image_tag >>"
+  #           CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push "signon-tasks-<< parameters.environment_key >>" \
+  #                                                              -f tasks_deploy_manifest.yml \
+  #                                                              --no-route \
+  #                                                              --task \
+  #                                                              --docker-image "$ECR_REPO/$DOCKER_IMAGE:$DOCKER_TAG" \
+  #                                                              --docker-username "$AWS_ACCESS_KEY_ID"
+  #     - run_migrations:
+  #         environment_key: << parameters.environment_key >>
 
-  sentry-release:
-    steps:
-      - checkout
-      - run:
-          name: Create release and notify Sentry of deploy
-          command: |
-            sudo curl -sL \
-                      -o /usr/local/bin/sentry-cli \
-                      https://github.com/getsentry/sentry-cli/releases/download/1.74.3/sentry-cli-Linux-x86_64
-            sudo chmod 0755 /usr/local/bin/sentry-cli
-            export SENTRY_RELEASE=$(sentry-cli releases propose-version)
-            sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE &&
-              sentry-cli releases set-commits $SENTRY_RELEASE --auto &&
-              sentry-cli releases finalize $SENTRY_RELEASE &&
-              sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT ||
-              /usr/bin/true # prevent sentry outage from blocking deploys - see HOTT-1570
+  # sentry-release:
+  #   steps:
+  #     - checkout
+  #     - run:
+  #         name: Create release and notify Sentry of deploy
+  #         command: |
+  #           sudo curl -sL \
+  #                     -o /usr/local/bin/sentry-cli \
+  #                     https://github.com/getsentry/sentry-cli/releases/download/1.74.3/sentry-cli-Linux-x86_64
+  #           sudo chmod 0755 /usr/local/bin/sentry-cli
+  #           export SENTRY_RELEASE=$(sentry-cli releases propose-version)
+  #           sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE &&
+  #             sentry-cli releases set-commits $SENTRY_RELEASE --auto &&
+  #             sentry-cli releases finalize $SENTRY_RELEASE &&
+  #             sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT ||
+  #             /usr/bin/true # prevent sentry outage from blocking deploys - see HOTT-1570
 
-  run_migrations:
-    parameters:
-      service:
-        type: string
-      environment_key:
-        type: string
-    steps:
-      - run:
-          name: "Run Migrations"
-          command: |
-            cf run-task "signon-tasks-<< parameters.environment_key >>" --command "cd app && bundle exec rails db:migrate" --name "db-migrate" --wait
+  # run_migrations:
+  #   parameters:
+  #     service:
+  #       type: string
+  #     environment_key:
+  #       type: string
+  #   steps:
+  #     - run:
+  #         name: "Run Migrations"
+  #         command: |
+  #           cf run-task "signon-tasks-<< parameters.environment_key >>" --command "cd app && bundle exec rails db:migrate" --name "db-migrate" --wait
 
 jobs:
   linters:
@@ -275,30 +264,29 @@ jobs:
           event: fail
           template: basic_fail_1
 
-  # deploy_dev:
-  #   docker:
-  #     - image: cimg/ruby:2.7.6
-  #   environment:
-  #     SENTRY_ENVIRONMENT: "development"
-  #   steps:
-  #     - queue/until_front_of_line:
-  #         time: "10"
-  #         consider-branch: false
-  #         dont-quit: true
-  #     - cf_deploy_docker_tasks:
-  #         docker_image_tag: dev-$CIRCLE_SHA1
-  #         space: "development"
-  #         environment_key: "dev"
-  #     - cf_deploy_docker_worker:
-  #         docker_image_tag: dev-$CIRCLE_SHA1
-  #         space: "development"
-  #         environment_key: "dev"
-  #     - cf_deploy_docker:
-  #         docker_image_tag: dev-$CIRCLE_SHA1
-  #         space: "development"
-  #         environment_key: "dev"
-  #         domain_prefix: "dev"
-  #     - sentry-release
+  deploy_dev:
+    docker:
+      - image: cimg/ruby:2.7.6
+    environment:
+      SENTRY_ENVIRONMENT: "development"
+    steps:
+      - queue/until_front_of_line:
+          time: "10"
+          consider-branch: false
+          dont-quit: true
+      # - cf_deploy_docker_tasks:
+      #     docker_image_tag: dev-$CIRCLE_SHA1
+      #     space: "development"
+      #     environment_key: "dev"
+      # - cf_deploy_docker_worker:
+      #     docker_image_tag: dev-$CIRCLE_SHA1
+      #     space: "development"
+      #     environment_key: "dev"
+      - cf_deploy_docker:
+          docker_image_tag: dev-$CIRCLE_SHA1
+          space: "development"
+          environment_key: "dev"
+      # - sentry-release
 
 workflows:
   version: 2
@@ -321,13 +309,13 @@ workflows:
               ignore:
                 - main
                 - /^dependabot\/.*/
-      # - deploy_dev:
-      #     context: trade-tariff
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - main
-      #           - /^dependabot\/.*/
-      #     requires:
-      #       - test
-      #       - build_dev
+      - deploy_dev:
+          context: trade-tariff
+          filters:
+            branches:
+              ignore:
+                - main
+                - /^dependabot\/.*/
+          requires:
+            - test
+            - build_dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,11 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@2.0.3
-  ruby: circleci/ruby@1
+  browser-tools: circleci/browser-tools@1.1
   cloudfoundry: circleci/cloudfoundry@1.0
-  slack: circleci/slack@4.3.0
   queue: eddiewebb/queue@1.6.4
+  ruby: circleci/ruby@1
+  slack: circleci/slack@4.3.0
   tariff: trade-tariff/trade-tariff-ci-orb@0 # can also change to @dev:<gitsha> for specific version or @dev:alpha to test dev branches
 
 commands:
@@ -238,12 +239,11 @@ jobs:
 
   test:
     docker:
-      - image: cimg/ruby:2.7.6
+      - image: cimg/ruby:2.7.6-node
         environment:
           BUNDLE_JOBS: "3"
           BUNDLE_RETRY: "3"
           RAILS_ENV: "test"
-          DATABASE_URL: "mysql://signonotron2:signonotron2@localhost:3306/signonotron2_test"
           REDIS_URL: "redis://localhost:6379"
       - image: cimg/mysql:8.0
         environment:
@@ -254,16 +254,14 @@ jobs:
     resource_class: medium
     steps:
       - checkout
+      - browser-tools/install-chrome
       - run:
           name: "Install OS packages"
           command: |
             sudo apt-get update
             sudo apt-get install -y --no-install-suggests --no-install-recommends nodejs libmariadb-dev-compat
       - ruby/install-deps
-      - run:
-          name: "Setup DB"
-          command: |
-            RAILS_ENV=test bundle exec rails db:schema:load
+      - run: "RAILS_ENV=test bundle exec rails db:schema:load --trace"
       - run:
           name: "Run tests"
           command: |

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+### Jira link
+
+HOTT-<TODO>
+
+### What?
+
+I have added/removed/altered:
+
+- [ ] Added foo in bar
+- [ ] Removed baz
+
+### Why?
+
+I am doing this because:
+
+-
+-
+-
+
+### AC
+
+- [ ] Meets criteria A
+- [ ] Meets criteria B

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ yarn-error.log
 
 # Ignore compiled Rails assets
 /public/assets
+
+*manifest*.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,4 +70,5 @@ COPY --from=builder /app ./
 RUN groupadd -g 1001 app && \
     useradd -u 1001 -g app app
 USER 1001
-CMD bundle exec puma
+
+CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]

--- a/Gemfile
+++ b/Gemfile
@@ -61,8 +61,10 @@ group :test do
   gem "minitest"
   gem "mocha", require: false
   gem "rails-controller-testing"
+  gem "selenium-webdriver"
   gem "shoulda-context", require: false
   gem "simplecov"
   gem "timecop"
+  gem "webdrivers"
   gem "webmock"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -43,8 +43,8 @@ gem "govuk_sidekiq"
 gem "plek"
 
 # Online Trade Tariff
-gem 'lograge'
-gem 'logstash-event'
+gem "lograge"
+gem "logstash-event"
 
 group :development do
   gem "better_errors"

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,10 @@ gem "govuk_publishing_components"
 gem "govuk_sidekiq"
 gem "plek"
 
+# Online Trade Tariff
+gem 'lograge'
+gem 'logstash-event'
+
 group :development do
   gem "better_errors"
   gem "binding_of_caller"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -454,6 +454,10 @@ GEM
       macaddr (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
+    webdrivers (5.0.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -519,6 +523,7 @@ DEPENDENCIES
   rqrcode
   rubocop-govuk
   sassc-rails
+  selenium-webdriver
   sentry-sidekiq
   shoulda-context
   simplecov
@@ -526,6 +531,7 @@ DEPENDENCIES
   timecop
   uglifier
   uuid
+  webdrivers
   webmock
   whenever
   zeroclipboard-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,6 +225,12 @@ GEM
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    lograge (0.12.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
+    logstash-event (1.2.02)
     logstasher (2.1.5)
       activesupport (>= 5.2)
       request_store
@@ -506,6 +512,8 @@ DEPENDENCIES
   json
   kaminari
   listen
+  lograge
+  logstash-event
   mail-notify
   minitest
   mocha

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,19 +2,21 @@ default: &default
   adapter: mysql2
   encoding: utf8
   reconnect: true
-  username: signonotron2
-  password: signonotron2
   pool: 5
 
 development:
   <<: *default
+  host: 127.0.0.1
+  username: signonotron2
+  password: signonotron2
   database: signonotron2_development
-  url: <%= ENV["DATABASE_URL"] %>
 
 test: &test
   <<: *default
+  host: 127.0.0.1
+  username: signonotron2
+  password: signonotron2
   database: signonotron2_test
-  url: <%= ENV["TEST_DATABASE_URL"] %>
 
 production:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,7 +11,7 @@ development:
   password: signonotron2
   database: signonotron2_development
 
-test: &test
+test:
   <<: *default
   host: 127.0.0.1
   username: signonotron2
@@ -19,5 +19,8 @@ test: &test
   database: signonotron2_test
 
 production:
-  <<: *default
-  url: <%= ENV["DATABASE_URL"] %>
+  adapter: mysql2
+  encoding: utf8
+  reconnect: true
+  pool: 5
+  url: <%= "#{ENV['DATABASE_URL']}&ssl_mode=required" if Rails.env.production? %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,11 +86,9 @@ Rails.application.configure do
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new($stdout)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
+  config.logger = ActiveSupport::Logger.new($stdout)
+  config.lograge.enabled = true
+  config.lograge.formatter = Lograge::Formatters::Logstash.new
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/config/initializers/mysql.rb
+++ b/config/initializers/mysql.rb
@@ -1,0 +1,1 @@
+Mysql2::Client.default_query_options[:connect_flags] |= Mysql2::Client::SSL if Rails.env.production?

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,12 @@
+require "sidekiq"
+require "paas_config"
+
+redis_config = PaasConfig.redis
+
+Sidekiq.configure_server do |config|
+  config.redis = redis_config
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = redis_config
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "2"
+services:
+  hmrc-redis:
+    container_name: redis
+    image: redis
+    ports:
+      - 6379:6379
+    volumes:
+      - hmrc-redis:/data
+  hmrc-mysql:
+    container_name: hmrc-mysql
+    image: mysql:8.0.30
+    environment:
+      - MYSQL_DATABASE=signonotron2_development
+      - MYSQL_USER=signonotron2
+      - MYSQL_PASSWORD=signonotron2
+      - MYSQL_ROOT_PASSWORD=
+      - MYSQL_ALLOW_EMPTY_PASSWORD=true
+    ports:
+      - 3306:3306
+    volumes:
+      - hmrc-mysql-8:/var/lib/mysql

--- a/lib/paas_config.rb
+++ b/lib/paas_config.rb
@@ -1,8 +1,6 @@
 class PaasConfig
   def self.redis
     url = begin
-      # TODO: !Important
-      # need to fetch by service name if we use multiple redis services
       JSON.parse(ENV["VCAP_SERVICES"])["redis"][0]["credentials"]["uri"]
     rescue StandardError
       ENV["REDIS_URL"]

--- a/lib/paas_config.rb
+++ b/lib/paas_config.rb
@@ -1,0 +1,13 @@
+class PaasConfig
+  def self.redis
+    url = begin
+      # TODO: !Important
+      # need to fetch by service name if we use multiple redis services
+      JSON.parse(ENV["VCAP_SERVICES"])["redis"][0]["credentials"]["uri"]
+    rescue StandardError
+      ENV["REDIS_URL"]
+    end
+
+    { url: url, db: Rails.env.test? ? 1 : 0, id: nil }
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,7 +26,7 @@ end
 
 WebMock.disable_net_connect!({
   allow_localhost: true,
-  allow: 'chromedriver.storage.googleapis.com'
+  allow: "chromedriver.storage.googleapis.com",
 })
 
 require "support/confirmation_token_helpers"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,7 +24,10 @@ class ActiveSupport::TestCase
   end
 end
 
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!({
+  allow_localhost: true,
+  allow: 'chromedriver.storage.googleapis.com'
+})
 
 require "support/confirmation_token_helpers"
 


### PR DESCRIPTION
**What**

- [x] Adds working docker-compose file
- [x] Adds unattended webdriver installation
- [x] Make database configuration conform to our standards
- [x] Adds PR template
- [ ] Adds circle ci configuration for test integration and deploys (currently only dev)
- [x] Adds PaaS redis configuration

**Why**

We have a seriously out of date configuration for signonotron (not signonotron2) which:
- requires a whole bunch of major dep updates to bring inline
- is not supported by a maintained upstream
- is not compatible with infrastructure we're going to be forced to use
- has been managed very poorly over the years and needs a lot of love
